### PR TITLE
Nerf to Bloodrage Spell amp

### DIFF
--- a/game/dota_addons/ebf/scripts/npc/heroes/hero_bloodseeker.txt
+++ b/game/dota_addons/ebf/scripts/npc/heroes/hero_bloodseeker.txt
@@ -79,8 +79,8 @@
 			}
 			"spell_amp"		
 			{
-				"value"										"15 20 25 30 35 40 45"
-				"special_bonus_unique_bloodseeker_6"		"+10"
+				"value"										"5 8 11 14 17 20 23"
+				"special_bonus_unique_bloodseeker_6"		"+7"
 				"CalculateAttributeTooltip"					"1"
 			}
 			"allied_attack_speed"		
@@ -90,8 +90,8 @@
 			}
 			"allied_spell_amp"		
 			{
-				"value"										"5 10 15 20 25 30 35"
-				"special_bonus_unique_bloodseeker_6"		"+10"
+				"value"										"2 5 8 11 14 17 20"
+				"special_bonus_unique_bloodseeker_6"		"+7"
 				"CalculateAttributeTooltip"					"1"
 			}
 			"damage_pct"
@@ -451,7 +451,7 @@
 			"01"
 			{
 				"var_type"					"FIELD_INTEGER"
-				"value"						"16"
+				"value"						"7"
 				"ad_linked_abilities"		"bloodseeker_bloodrage"				// this is the ability this bonus affects.  This line is required for Ability Draft to correctly choose talents.
 			}
 		}


### PR DESCRIPTION
Not sure why bloodseeker talent skill said it gives 10 previously, but there's also a line saying it gives 16? anyway i nerfed both, if reasonable.
Bloodseeker would get like 250% and allies 200% spell amp by level 25. (if my public school math is right)
Also increased duration by 2 seconds , just so you dont have to crackhead smash the button as soon as cooldown wears off
